### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ reports/
 projects/
 
 # Tool-specific
+.claude/
 .playwright-mcp/
 .serena/
 .auto-claude/


### PR DESCRIPTION
Closes #65

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .gitignore