### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,6 @@ reports/
 projects/
 
 # Tool-specific
-.claude/settings.json
 .claude/settings.local.json
 .claude/todos/
 .claude/worktrees/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,8 @@ repos:
 
   # ===========================================================================
   # Shell script analysis — config: .shellcheckrc (SC2016 disabled there)
-  # Replaces: shellcheck in super-linter (was passing SHELLCHECK_OPTS="-e SC2016")
+  # Replaces: shellcheck in super-linter
+  # (was passing SHELLCHECK_OPTS="-e SC2016")
   # ===========================================================================
   - repo: local
     hooks:
@@ -154,7 +155,7 @@ repos:
     hooks:
       - id: zizmor
         name: GitHub Actions security
-        entry: zizmor --config zizmor.yaml
+        entry: zizmor --config zizmor.yaml .github/workflows/
         language: system
         files: ^\.github/workflows/.*\.ya?ml$
         pass_filenames: false
@@ -187,8 +188,9 @@ repos:
 ci:
   autofix_prs: true
   autoupdate_schedule: weekly
-  # All language: system hooks require tools installed in the runner —
-  # skip them in pre-commit.ci (cloud) since the environment lacks these binaries.
+  # All language: system hooks require tools installed
+  # in the runner — skip them in pre-commit.ci (cloud)
+  # since the environment lacks these binaries.
   # They run locally and in GitHub Actions CI where tools are pre-installed.
   skip:
     - local-hooks

--- a/zizmor.yaml
+++ b/zizmor.yaml
@@ -46,3 +46,9 @@ rules:
   # for reusable workflows
   secrets-inherit:
     disable: true
+  # Governance workflows intentionally use
+  # secrets without dedicated environments;
+  # environment-based access control is not
+  # needed for org-internal automation tokens
+  secrets-outside-env:
+    disable: true


### PR DESCRIPTION
Closes #120

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .gitignore
- .pre-commit-config.yaml
- zizmor.yaml